### PR TITLE
Update context flag in PR command for parity with commit command

### DIFF
--- a/cmd/pr.go
+++ b/cmd/pr.go
@@ -26,7 +26,7 @@ func init() {
 	prCmd.Flags().BoolP("draft", "d", false, "Create a draft pull request")
 	prCmd.Flags().Bool("dry-run", false, "Show what would be done without creating the PR")
 	prCmd.Flags().BoolP("yes", "y", false, "Skip confirmation prompt and create PR immediately")
-	prCmd.Flags().String("context", "c", "Additional context to include in the PR generation")
+	prCmd.Flags().StringP("context", "c", "", "Additional context to include in the PR generation")
 }
 
 func runPR(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
## Summary:
This PR addresses the need to update the context flag description in the PR command for consistency with the commit command.

## Changes Made:
- Fixed the context flag description in the PR command to align with the commit command
- Added a -c flag to the PR command for better parity with the commit command

## Testing:
- Manual testing performed to ensure the updated context flag works as expected
- Tested the PR command with various scenarios to verify the changes

## Additional Notes:
The addition of the -c flag improves the coherence between the commit and PR commands, enhancing user experience and maintaining consistency throughout the tool.